### PR TITLE
Align UI with Mad Angel Films color palette

### DIFF
--- a/SRTEditor.UI/MainForm.Designer.cs
+++ b/SRTEditor.UI/MainForm.Designer.cs
@@ -333,13 +333,14 @@ partial class MainForm
         // subtitleListView
         // 
         subtitleListView.AutoSizeTable = false;
-        subtitleListView.BackColor = Color.FromArgb(255, 255, 255);
+        subtitleListView.BackColor = Color.FromArgb(26, 26, 26);
         subtitleListView.BorderStyle = BorderStyle.None;
         subtitleListView.Columns.AddRange(new ColumnHeader[] { sequenceColumnHeader, startColumnHeader, endColumnHeader, textColumnHeader });
         subtitleListView.Depth = 0;
         subtitleListView.Dock = DockStyle.Fill;
         subtitleListView.FullRowSelect = true;
         subtitleListView.HideSelection = false;
+        subtitleListView.ForeColor = Color.FromArgb(242, 242, 240);
         subtitleListView.Location = new Point(4, 40);
         subtitleListView.Margin = new Padding(4);
         subtitleListView.MinimumSize = new Size(200, 200);
@@ -413,7 +414,7 @@ partial class MainForm
         // 
         // videoPanel
         // 
-        videoPanel.BackColor = Color.FromArgb(18, 18, 18);
+        videoPanel.BackColor = Color.FromArgb(11, 29, 58);
         videoPanel.Controls.Add(videoPlaceholderLabel);
         videoPanel.Dock = DockStyle.Fill;
         videoPanel.Location = new Point(4, 40);
@@ -426,7 +427,7 @@ partial class MainForm
         // 
         videoPlaceholderLabel.Dock = DockStyle.Fill;
         videoPlaceholderLabel.Font = new Font("Segoe UI", 12F, FontStyle.Italic, GraphicsUnit.Point);
-        videoPlaceholderLabel.ForeColor = Color.WhiteSmoke;
+        videoPlaceholderLabel.ForeColor = Color.FromArgb(242, 242, 240);
         videoPlaceholderLabel.Location = new Point(0, 0);
         videoPlaceholderLabel.Name = "videoPlaceholderLabel";
         videoPlaceholderLabel.Size = new Size(982, 426);
@@ -534,12 +535,13 @@ partial class MainForm
         // subtitleTextBox
         // 
         subtitleTextBox.AnimateReadOnly = false;
-        subtitleTextBox.BackColor = Color.FromArgb(242, 242, 242);
+        subtitleTextBox.BackColor = Color.FromArgb(242, 242, 240);
         subtitleTextBox.Depth = 0;
         subtitleTextBox.Dock = DockStyle.Fill;
         subtitleTextBox.Enabled = false;
         subtitleTextBox.Font = new Font("Roboto", 16F, FontStyle.Regular, GraphicsUnit.Pixel);
         subtitleTextBox.HideSelection = true;
+        subtitleTextBox.ForeColor = Color.FromArgb(26, 26, 26);
         subtitleTextBox.Location = new Point(4, 647);
         subtitleTextBox.Margin = new Padding(4);
         subtitleTextBox.MaxLength = 1500;

--- a/SRTEditor.UI/MainForm.cs
+++ b/SRTEditor.UI/MainForm.cs
@@ -33,10 +33,10 @@ public partial class MainForm : MaterialForm
         manager.AddFormToManage(this);
         manager.Theme = MaterialSkinManager.Themes.DARK;
         manager.ColorScheme = new ColorScheme(
-            Color.FromArgb(0x21, 0x21, 0x21),
-            Color.FromArgb(0x0D, 0x47, 0xA1),
-            Color.FromArgb(0x12, 0x36, 0x6F),
-            Color.FromArgb(0xFF, 0x6F, 0x00),
+            Color.FromArgb(0x7C, 0x0A, 0x02),
+            Color.FromArgb(0x4A, 0x00, 0x00),
+            Color.FromArgb(0x99, 0x2A, 0x1C),
+            Color.FromArgb(0xC2, 0x9F, 0x13),
             TextShade.WHITE);
     }
 


### PR DESCRIPTION
## Summary
- apply the Mad Angel Films brand colors to the MaterialSkin color scheme
- update UI element foregrounds and backgrounds to match the refreshed palette

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e51d6d088c832395e8e89b92a819a3