### PR TITLE
Ensure subtitle selection starts playback from entry start

### DIFF
--- a/SRTEditor.UI/MainForm.cs
+++ b/SRTEditor.UI/MainForm.cs
@@ -299,15 +299,16 @@ public partial class MainForm : MaterialForm
         string endText = entry.EndTime.ToString(@"hh\:mm\:ss\.fff", CultureInfo.InvariantCulture);
         subtitleTimingLabel.Text = $"Start: {startText}  End: {endText}";
         subtitleTextBox.Text = entry.Text;
-        if (_mediaPlayer is MediaPlayer player && player.Media is not null && player.IsSeekable)
+        if (_mediaPlayer is MediaPlayer player && player.Media is not null)
         {
             long startMilliseconds = (long)entry.StartTime.TotalMilliseconds;
-            player.Time = startMilliseconds;
-            UpdateTrackBarFromMediaTime(startMilliseconds, player.Length);
             if (!_suppressAutoPlay)
             {
                 EnsurePlaybackRunning();
             }
+
+            player.Time = startMilliseconds;
+            UpdateTrackBarFromMediaTime(startMilliseconds, player.Length);
         }
     }
 


### PR DESCRIPTION
## Summary
- remove the seekable guard when handling subtitle selections so the media player always jumps to the entry start time
- trigger playback when a user selects an entry (unless auto play is suppressed) to honor the expected behavior

## Testing
- dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e58a58eae08323a40d021a83d4eb3d